### PR TITLE
Support 256 color

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "test": "istanbul cover _mocha"
   },
-  "dependencies": {},
+  "dependencies": {
+    "color-convert": "^1.9.1"
+  },
   "devDependencies": {
     "chai": "3.5.0",
     "coveralls": "2.12.0",

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -23,11 +23,14 @@ class Canvas {
    * @param {Stream} [options.stream=process.stdout] Writable stream
    * @param {Number} [options.width=stream.columns] Number of columns (width)
    * @param {Number} [options.height=stream.rows] Number of rows (height)
+   * @param {Number} [options.height=stream.rows] Number of rows (height)
+   * @param {Object} [options.colorSupport] Object with color support
+   * @param {Boolean} [options.colorSupport.has16m] Support true color
    * @example
    * Canvas.create({stream: fs.createWriteStream(), width: 20, height: 20});
    */
   constructor(options = {}) {
-    var {stream = process.stdout, width = stream.columns, height = stream.rows} = options;
+    var {stream = process.stdout, width = stream.columns, height = stream.rows, colorSupport = { has16m: true }} = options;
 
     this._stream = stream;
     this._width = width;
@@ -39,7 +42,7 @@ class Canvas {
     this._foreground = {r: -1, g: -1, b: -1};
     this._display = {bold: false, dim: false, underlined: false, blink: false, reverse: false, hidden: false};
 
-    this._cells = Array.from({length: width * height}).map(() => new Cell());
+    this._cells = Array.from({length: width * height}).map(() => new Cell(undefined, { colorSupport }));
     this._lastFrame = Array.from({length: width * height}).fill('');
   }
 

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -23,7 +23,6 @@ class Canvas {
    * @param {Stream} [options.stream=process.stdout] Writable stream
    * @param {Number} [options.width=stream.columns] Number of columns (width)
    * @param {Number} [options.height=stream.rows] Number of rows (height)
-   * @param {Number} [options.height=stream.rows] Number of rows (height)
    * @param {Object} [options.colorSupport] Object with color support
    * @param {Boolean} [options.colorSupport.has16m] Support true color
    * @example

--- a/src/Color.js
+++ b/src/Color.js
@@ -1,4 +1,5 @@
 const COLORS = require('./util/colors');
+const convert = require('color-convert');
 
 /**
  * Regular expression for capturing RGB channels.
@@ -132,6 +133,17 @@ class Color {
   toHex() {
     const pad2 = c => c.length === 1 ? '0' + c : c;
     return '#' + [pad2(this.getR().toString(16)), pad2(this.getG().toString(16)), pad2(this.getB().toString(16))].join('');
+  }
+
+  /**
+   * Convert and return 256 color number.
+   *
+   * @returns {Number}
+   */
+  to256Color() {
+    const { r, g, b } = this.toRgb();
+
+    return convert.rgb.ansi256(r, g, b);
   }
 
   /**

--- a/test/unit/Cell.test.js
+++ b/test/unit/Cell.test.js
@@ -154,7 +154,7 @@ describe('Cell', () => {
   });
 
   it('Should properly convert Cell into ASCII sequence', () => {
-    const cell = new Cell();
+    const cell = new Cell(undefined, { colorSupport: { has16m: true } });
 
     assert.equal(cell.toString(), '\u001b[1;1f \u001b[0m');
     assert.instanceOf(cell.setX(20), Cell);

--- a/test/unit/Cell.test.js
+++ b/test/unit/Cell.test.js
@@ -154,7 +154,8 @@ describe('Cell', () => {
   });
 
   it('Should properly convert Cell into ASCII sequence', () => {
-    const cell = new Cell(undefined, { colorSupport: { has16m: true } });
+    const colorSupport = { has16m: true };
+    const cell = new Cell(undefined, { colorSupport });
 
     assert.equal(cell.toString(), '\u001b[1;1f \u001b[0m');
     assert.instanceOf(cell.setX(20), Cell);
@@ -167,6 +168,14 @@ describe('Cell', () => {
     assert.equal(cell.toString(), '\u001b[11;21f\u001b[48;2;0;100;200m\u001b[38;2;200;100;0m \u001b[0m');
     assert.instanceOf(cell.setDisplay(true, true, true, true, true, true), Cell);
     assert.equal(cell.toString(), '\u001b[11;21f\u001b[48;2;0;100;200m\u001b[38;2;200;100;0m\u001b[1m\u001b[2m\u001b[4m\u001b[5m\u001b[7m\u001b[8m \u001b[0m');
+
+    colorSupport.has16m = false;
+    cell.reset();
+
+    assert.instanceOf(cell.setBackground(0, 100, 200), Cell);
+    assert.equal(cell.toString(), '\u001b[11;21f\u001b[48;5;32m \u001b[0m');
+    assert.instanceOf(cell.setForeground(200, 100, 0), Cell);
+    assert.equal(cell.toString(), '\u001b[11;21f\u001b[48;5;32m\u001b[38;5;172m \u001b[0m');
   });
 
   it('Should properly create Cell instance from static create()', () => {

--- a/test/unit/Color.test.js
+++ b/test/unit/Color.test.js
@@ -135,4 +135,9 @@ describe('Color', () => {
     assert.equal(color._g, 0);
     assert.equal(color._b, 0);
   });
+
+  it('Should properly convert to 256 color number', () => {
+    assert.equal(Color.create('black').to256Color(), 16);
+    assert.equal(Color.create('#ff0000').to256Color(), 196);
+  });
 });


### PR DESCRIPTION
```javascript
// By default, use 24-bit color
var canvas = Canvas.create();

// Use 256 color manually
var canvas = Canvas.create({ colorSupport: { has16m: false });

// Guess whether the terminal supports 24-bit color
// If not, use 256 color
var colorSupport = require('color-support')();
var canvas = Canvas.create({ colorSupport });
```

